### PR TITLE
[object Object]の修正

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -27,7 +27,7 @@ import productImage from '../assets/images/service.jpg'
 
 
 const title = "omeroid"
-const content = ["エンジニア・コンサルタントのプロ集団", <br />, "「Make it simple」をテーマに顧客のビジネスサポートや自社サービス開発を行っています"]
+const content = "エンジニア・コンサルタントのプロ集団「Make it simple」をテーマに顧客のビジネスサポートや自社サービス開発を行っています"
 // const gptSiteSearchLoaderUrl = "https://dev-gpt-site-search-sdk.s3.ap-northeast-1.amazonaws.com/loader/index.js"
 
 class HomeIndex extends React.Component {


### PR DESCRIPTION
添付画像のように[object Object]になるのを修正

![image](https://github.com/user-attachments/assets/7646e703-097b-4c7c-a064-1c2742fc19ec)


metaタグのdescriptionの中で実質改行は使えないらしい
https://stackoverflow.com/questions/6179889/google-meta-description-line-break-possible